### PR TITLE
Debugging

### DIFF
--- a/include/Action.h
+++ b/include/Action.h
@@ -76,8 +76,8 @@ public:
 	virtual std::string toString() const;
 	virtual BaseAction* clone() const;
 private:
-    const std::string _newUserName;
     const std::string _oldUserName;
+    const std::string _newUserName;
 };
 
 class PrintContentList : public BaseAction {

--- a/include/User.h
+++ b/include/User.h
@@ -21,6 +21,7 @@ public:
     std::vector<Watchable*> get_history() const;
     virtual void addToHistory(Watchable&);
     bool isInHistory(const Watchable&);
+    void setName(const std::string&);
 protected:
     std::vector<Watchable*> history;
 private:

--- a/include/User.h
+++ b/include/User.h
@@ -22,6 +22,7 @@ public:
     virtual void addToHistory(Watchable&);
     bool isInHistory(const Watchable&);
     void setName(const std::string&);
+    void fixHistory(std::vector<Watchable*>& content);
 protected:
     std::vector<Watchable*> history;
 private:

--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -146,6 +146,7 @@ std::string PrintContentList::toString() const {
 PrintWatchHistory::~PrintWatchHistory() {}
 
 void PrintWatchHistory::act(Session& sess) {
+    std::cout << "Watch history for " << sess.getActiveUser().getName() std::endl;
     const std::vector<Watchable*> history = sess.getActiveUser().get_history();
     int i = 1; // 1 for easier readabillity, where lists start at 1
     for(auto watchable: history)

--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -102,9 +102,9 @@ std::string DeleteUser::toString() const {
     return ("DeleteUser " + getStatusString());
 }
 
-DuplicateUser::DuplicateUser(const std::string& newUser, const std::string& oldUser): BaseAction(),
-                                                                                      _newUserName(newUser),
-                                                                                      _oldUserName(oldUser){}
+DuplicateUser::DuplicateUser(const std::string& oldUser, const std::string& newUser): BaseAction(),
+                                                                                      _oldUserName(oldUser),
+                                                                                      _newUserName(newUser){}
 
 DuplicateUser::~DuplicateUser() {}
 

--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -146,7 +146,7 @@ std::string PrintContentList::toString() const {
 PrintWatchHistory::~PrintWatchHistory() {}
 
 void PrintWatchHistory::act(Session& sess) {
-    std::cout << "Watch history for " << sess.getActiveUser().getName() std::endl;
+    std::cout << "Watch history for " << sess.getActiveUser().getName() << std::endl;
     const std::vector<Watchable*> history = sess.getActiveUser().get_history();
     int i = 1; // 1 for easier readabillity, where lists start at 1
     for(auto watchable: history)

--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -28,6 +28,7 @@ void BaseAction::complete() {
 void BaseAction::error(const std::string& errorMsg) {
     this->errorMsg = errorMsg;
     status = ERROR;
+    std::cout << "ERROR - " << errorMsg << std::endl;
 }
 
 std::string BaseAction::getErrorMsg() const {

--- a/src/Action.cpp
+++ b/src/Action.cpp
@@ -118,6 +118,7 @@ void DuplicateUser::act(Session &sess) {
     else {
         User& oldUser = *(usersMap.at(_oldUserName));
         User* newUser = oldUser.clone();
+        newUser->setName(_newUserName);
         sess.addToUserMap(newUser);
     }
 }

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -81,11 +81,7 @@ void Session::start() {
                 break;
             }
             case DUP_USER: {
-                /*
-                    dupuser <original_username> <new_username> as opposed to
-                    the constructor with the reverse order
-                */
-                actionObj = new DuplicateUser(actionParams[2], actionParams[1]);
+                actionObj = new DuplicateUser(actionParams[1], actionParams[2]);
                 actionsLog.push_back(actionObj);
                 actionObj->act(*this);
                 break;
@@ -103,9 +99,9 @@ void Session::start() {
                 break;
             }
             case WATCH: {
-                long nextId = std::stol(actionParams[1]);
+                long nextId = std::stol(actionParams[1])-1;
                 std::string continueWatch;
-                Watch *watchObj = new Watch(*(content[nextId-1]));
+                Watch *watchObj = new Watch(*(content[nextId]));
                 actionsLog.push_back(watchObj);
                 watchObj->act(*this);
                 while ((nextId = watchObj->getNextWatchableId()) != NOTHING_TO_RECOMMEND) {
@@ -222,8 +218,8 @@ void Session::cleanIterable(T* toDelete) //T should be iterable
     for(auto w: *toDelete)
     {
         delete w;
+        w = nullptr;
     }
-    toDelete->clear();
 }
 
 void Session::cleanUserMap()
@@ -231,9 +227,8 @@ void Session::cleanUserMap()
     for(auto w: userMap)
     {
         delete w.second;
-        w.second = nullptr;
+        w = nullptr;
     }
-    userMap.clear();
 }
 
 void Session::clean() {
@@ -250,7 +245,7 @@ Session::Session(const Session &rhs)
     this->deepCopyPointerVector(rhs.content, this->content);
     this->deepCopyPointerVector(rhs.actionsLog, this->actionsLog);
     this->deepCopyUsers(rhs.userMap);
-    this->activeUser = userMap[rhs.activeUser->getName()];
+    this->activeUser = this->userMap[rhs.activeUser->getName()];
 }
 
 void Session::deepCopyUsers(const std::unordered_map<std::string, User*>& other)

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -223,6 +223,7 @@ void Session::cleanIterable(T* toDelete) //T should be iterable
     {
         delete w;
     }
+    toDelete->clear();
 }
 
 void Session::cleanUserMap()
@@ -230,7 +231,9 @@ void Session::cleanUserMap()
     for(auto w: userMap)
     {
         delete w.second;
+        w.second = nullptr;
     }
+    userMap.clear();
 }
 
 void Session::clean() {
@@ -241,15 +244,22 @@ void Session::clean() {
 }
 
 Session::Session(const Session &rhs)
-: content(rhs.content), actionsLog(rhs.actionsLog), userMap(rhs.userMap),
- activeUser(userMap[rhs.activeUser->getName()])
-{}
+: content(), actionsLog(), userMap(),
+ activeUser()
+{
+    this->deepCopyPointerVector(rhs.content, this->content);
+    this->deepCopyPointerVector(rhs.actionsLog, this->actionsLog);
+    this->deepCopyUsers(rhs.userMap);
+    this->activeUser = userMap[rhs.activeUser->getName()];
+}
 
 void Session::deepCopyUsers(const std::unordered_map<std::string, User*>& other)
 {
     for(auto u: other)
     {
-        *(this->userMap[u.first]) = *(u.second);
+        User* newUser = u.second->clone();
+        this->userMap[u.first] = newUser;
+        newUser->fixHistory(content);
     }
 }
 

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -167,7 +167,7 @@ void Session::fillContentFromJson(const std::string &configFilePath) {
             for(uint j = 0; j < episodesNum; j++)
             {
                 int nextEpisodeId = currentId+1;
-                if(j == seriesDesc["seasons"][i].size()-1 && i==seriesDesc["seasons"].size()-1)
+                if(j == episodesNum-1 && i==seriesDesc["seasons"].size()-1)
                     nextEpisodeId = 0;
                 //i+1 and j+1 because seasons and episodes start from 1
                 Episode* episodeObj = new Episode(currentId, seriesDesc["name"],

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -111,7 +111,7 @@ void Session::start() {
                     if (continueWatch != CONTINUE) {
                         break;
                     }
-                    watchObj = new Watch(*(content[nextId-1]));
+                    watchObj = new Watch(*(content[nextId]));
                     actionsLog.push_back(watchObj);
                     watchObj->act(*this);
                 }

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -81,7 +81,11 @@ void Session::start() {
                 break;
             }
             case DUP_USER: {
-                actionObj = new DuplicateUser(actionParams[1], actionParams[2]);
+                /*
+                    dupuser <original_username> <new_username> as opposed to
+                    the constructor with the reverse order
+                */
+                actionObj = new DuplicateUser(actionParams[2], actionParams[1]);
                 actionsLog.push_back(actionObj);
                 actionObj->act(*this);
                 break;

--- a/src/Session.cpp
+++ b/src/Session.cpp
@@ -161,8 +161,10 @@ void Session::fillContentFromJson(const std::string &configFilePath) {
     //iterate over tv series'. for each series and season add the corresponding episode
     for(auto seriesDesc: contentJson["tv_series"])
     {
+        // size() returns the size of the array, which in this case is the number of seasons
         for(uint i = 0; i < seriesDesc["seasons"].size(); i++)
         {
+            // Convert the content of the array into ints to use in the for loop
             uint episodesNum = seriesDesc["seasons"][i];
             for(uint j = 0; j < episodesNum; j++)
             {

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -30,7 +30,8 @@ void User::fixHistory(std::vector<Watchable*>& content)
     int index = 0;
     for(auto w : history)
     {
-        history[index++] = content[w->getId()];
+        history[index] = content[w->getId()];
+        index++;
     }
 }
 

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -25,6 +25,15 @@ void User::setName(const std::string& newName) {
     name = newName;
 }
 
+void User::fixHistory(std::vector<Watchable*>& content)
+{
+    int index = 0;
+    for(auto w : history)
+    {
+        history[index++] = content[w->getId()];
+    }
+}
+
 // Length Recommender User's methods implementation.
 LengthRecommenderUser::LengthRecommenderUser(const std::string& name): User(name), _avgWatchableLen(0.0f) {}
 

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -87,9 +87,15 @@ User* RerunRecommenderUser::clone() const{
 
 Watchable* RerunRecommenderUser::getRecommendation(Session& s) {
     if (_lastRecIdx == -1) {
+        _lastRecIdx ++;
         return *(history.begin());
     }
-    _lastRecIdx = (_lastRecIdx+1) % history.size();
+    /*
+        mod (size - 1) because we want to estimate the next index "before this content was watched"
+        so that for example if we last recommended 0 because the history was otherwise empty now we will
+        recommend 0 again, because the +1 should have happened before the history was lengthened
+    */
+    _lastRecIdx = (_lastRecIdx+1) % (history.size()-1);
     return history[_lastRecIdx];
 }
 

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -90,12 +90,7 @@ Watchable* RerunRecommenderUser::getRecommendation(Session& s) {
         _lastRecIdx ++;
         return *(history.begin());
     }
-    /*
-        mod (size - 1) because we want to estimate the next index "before this content was watched"
-        so that for example if we last recommended 0 because the history was otherwise empty now we will
-        recommend 0 again, because the +1 should have happened before the history was lengthened
-    */
-    _lastRecIdx = (_lastRecIdx+1) % (history.size()-1);
+    _lastRecIdx = (_lastRecIdx+1) % history.size();
     return history[_lastRecIdx];
 }
 

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -21,6 +21,9 @@ bool User::isInHistory(const Watchable& watchable) {
     return std::find(history.begin(), history.end(), &watchable) != history.end();
 }
 
+void User::setName(const std::string& newName) {
+    name = newName;
+}
 
 // Length Recommender User's methods implementation.
 LengthRecommenderUser::LengthRecommenderUser(const std::string& name): User(name), _avgWatchableLen(0.0f) {}

--- a/src/Watchable.cpp
+++ b/src/Watchable.cpp
@@ -50,11 +50,11 @@ Watchable* Movie::getNextWatchable(Session& s) const
 std::string Movie::toStringName() const
 {
     // According to the "Inglorious Basterds 153 minutes" format
-    return name+" ";
+    return name;
 }
 
 std::string Movie::toString() const {
-    return toStringName() + std::to_string(getLength())+" minutes " + getTagsString();
+    return toStringName() + " " + std::to_string(getLength())+" minutes " + getTagsString();
 }
 
 /* A second constructor for Episode is implemented with an extra paramter.


### PR DESCRIPTION
- Fix RO5 for session: Problem was that the content was changed but the users' history was still pointing at the old Watchable objects.
- Print every error upon encountering it (in the `Action::error`) function.
- We got nextId from the `getNextWatchableId()` and subtracted 1 from it.
- Movie had a space in `Movie::toStringName()` which was redundant
- json `size()` doesn't work the way I thought it does and I didn't fix it everywhere
- I added a `User::setName()` because when dupuser was called the new user's name wasn't changed (so there were 2 users with the same name). I also reversed the order of parameters given to `DuplicateUser`'s constructor to match the scheme given
- Added the proper "Watch history for" scheme